### PR TITLE
Adjust registry secret name

### DIFF
--- a/deploy/mlflow2seldon/templates/deployment.yaml
+++ b/deploy/mlflow2seldon/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
               echo "Creating registry secret"
               && neuro config login-with-token $M2S_MLFLOW_NEURO_TOKEN
               && neuro config switch-cluster $M2S_SRC_NEURO_CLUSTER
-              && neuro-extras k8s generate-registry-secret --name {{ .Values.serviceConfigs.M2S_NEURO_REGISTRY_SECRET}} | kubectl -n {{ .Values.serviceConfigs.M2S_SELDON_DEPLOYMENT_NS}} apply -f -
+              && export M2S_NEURO_REGISTRY_SECRET={{ $.Release.Name }}-platform-registry-auth
+              && neuro-extras k8s generate-registry-secret --name $M2S_NEURO_REGISTRY_SECRET | kubectl -n {{ .Values.serviceConfigs.M2S_SELDON_DEPLOYMENT_NS}} apply -f -
               && echo "Running the app"
               && exec mlflow2seldon

--- a/deploy/mlflow2seldon/values.yaml
+++ b/deploy/mlflow2seldon/values.yaml
@@ -2,9 +2,8 @@
 serviceAccountName: mlflow2seldon-sa
 
 serviceConfigName: mlflow2seldon-config
+# these placeholders will be replaced with their values in a Makefile
 serviceConfigs:
-  # these placeholders will be replaced with their values in a Makefile
-  M2S_NEURO_REGISTRY_SECRET: neuro-registry-auth
   # token to login on the platform cluster, where the MLFlow server is running
   M2S_MLFLOW_NEURO_TOKEN:
   M2S_MLFLOW_HOST:


### PR DESCRIPTION
Now we seem to be able to deploy several M2S instances in the same cluster for shared Seldon.